### PR TITLE
Sync gradle version with REAMDE

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,8 @@ repositories {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.firebase:firebase-core:+'
-    compile 'com.google.firebase:firebase-messaging:+'
+    compile 'com.google.firebase:firebase-core:10.0.1'
+    compile 'com.google.firebase:firebase-messaging:10.0.1'
     compile 'me.leolin:ShortcutBadger:1.1.10@aar'
 }
 


### PR DESCRIPTION
Setting the same version prevents build errors in some cases